### PR TITLE
Add vulnerability dna

### DIFF
--- a/agent/opengrep_agent.py
+++ b/agent/opengrep_agent.py
@@ -178,6 +178,7 @@ class OpengrepAgent(agent.Agent, agent_report_vulnerability_mixin.AgentReportVul
                 technical_detail=vuln.technical_detail,
                 risk_rating=vuln.risk_rating,
                 vulnerability_location=vuln.vulnerability_location,
+                dna=vuln.vuln_dna,
             )
 
 

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -8,6 +8,7 @@ import os
 import re
 from typing import Any, Iterator
 from urllib import parse
+import json
 
 
 import tenacity
@@ -43,6 +44,7 @@ class Vulnerability:
     entry: kb.Entry
     technical_detail: str
     risk_rating: vulnerability_mixin.RiskRating
+    vuln_dna: str
     vulnerability_location: vulnerability_mixin.VulnerabilityLocation | None = None
 
 
@@ -96,6 +98,51 @@ def filter_description(description: str) -> str:
         description,
     )
     return description
+
+
+def _sort_dict(dictionary: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
+    """Recursively sort dictionary keys and lists within.
+    Args:
+        dictionary: The dictionary to sort.
+    Returns:
+        A sorted dictionary or list.
+    """
+    if isinstance(dictionary, dict):
+        return {k: _sort_dict(v) for k, v in sorted(dictionary.items())}
+    if isinstance(dictionary, list):
+        return sorted(
+            dictionary,
+            key=lambda x: json.dumps(x, sort_keys=True)
+            if isinstance(x, dict)
+            else str(x),
+        )
+    return dictionary
+
+
+def _compute_vulnerability_dna(
+    title: str,
+    lines: str,
+    vulnerability_location: vulnerability_mixin.VulnerabilityLocation | None,
+) -> str:
+    """Compute a deterministic, debuggable DNA representation for a vulnerability.
+    Args:
+        title: Generate KB title.
+        lines: the lines where the vulnerability was detected.
+        vulnerability_location: the computed vulnerability location.
+    Returns:
+        A deterministic JSON representation of the vulnerability DNA.
+    """
+    dna_data: dict[str, Any] = {
+        "title": title,
+        "lines": lines,
+    }
+
+    if vulnerability_location is not None:
+        location_dict: dict[str, Any] = vulnerability_location.to_dict()
+        sorted_location_dict = _sort_dict(location_dict)
+        dna_data["location"] = sorted_location_dict
+
+    return json.dumps(dna_data, sort_keys=True)
 
 
 def _prepare_vulnerability_location(
@@ -160,6 +207,8 @@ def parse_results(
                 file_path=path, package_name=package_name, bundle_id=bundle_id
             )
 
+        lines = vulnerability["extra"].get("lines", "").strip()[:LINE_SIZE_MAX]
+
         yield Vulnerability(
             entry=kb.Entry(
                 title=title,
@@ -178,6 +227,7 @@ def parse_results(
             technical_detail=technical_detail,
             risk_rating=RISK_RATING_MAPPING[impact],
             vulnerability_location=vulnerability_location,
+            vuln_dna=_compute_vulnerability_dna(title, lines, vulnerability_location),
         )
 
 

--- a/tests/opengrep_agent_test.py
+++ b/tests/opengrep_agent_test.py
@@ -182,6 +182,11 @@ def testAgentOpengrep_whenAnalysisRunsWithoutErrors_emitsBackVulnerability(
     )
     assert vuln["vulnerability_location"]["android_store"] is not None
     assert vuln["vulnerability_location"]["android_store"]["package_name"] == "a.b.c"
+    assert vuln["dna"] == (
+        '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"android_store": '
+        '{"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '
+        '"title": "Cbc Padding Oracle"}'
+    )
 
 
 def testAgentOpengrep_whenAnalysisRunsWithoutPathWithoutErrors_emitsBackVulnerability(
@@ -250,6 +255,11 @@ def testAgentOpengrep_whenAnalysisRunsWithoutPathWithoutErrors_emitsBackVulnerab
         "```java\n"
         "Cipher cipher = Cipher.getInstance('AES/CBC/PKCS5Padding');\n"
         "```"
+    )
+    assert vuln["dna"] == (
+        '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"android_store":'
+        ' {"package_name": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "/tmp/tmpza6g8qu0.java"}]}, "tit'
+        'le": "Cbc Padding Oracle"}'
     )
 
 
@@ -432,3 +442,8 @@ def testAgentOpengrep_whenIosAsset_addsIosAssetToVulnLocation(
     )
     assert vuln["vulnerability_location"]["ios_store"] is not None
     assert vuln["vulnerability_location"]["ios_store"]["bundle_id"] == "a.b.c"
+    assert vuln["dna"] == (
+        '{"lines": "Cipher cipher = Cipher.getInstance(\'AES/CBC/PKCS5Padding\');", "location": {"ios_store": '
+        '{"bundle_id": "a.b.c"}, "metadata": [{"type": "FILE_PATH", "value": "tests/files/vulnerable.java"}]}, '
+        '"title": "Cbc Padding Oracle"}'
+    )


### PR DESCRIPTION
This PR computes and adds the dna attribute to the opengrep agent:
dna schema:
```json
{
    "lines": "the affected lines in file affected by the vuln.",
    "location": "dict value of the vulnerability location",
    "title": "vulnerability title given by opengrep"
}
```